### PR TITLE
Add script to fetch random Naver headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # hello-jaehyoek
+
+This repository contains a small script that fetches a random news
+headline from the Naver News website.
+
+## Requirements
+
+- Python 3.7 or higher
+- The `requests` and `beautifulsoup4` packages
+
+Install the packages with:
+
+```bash
+pip install requests beautifulsoup4
+```
+
+## Usage
+
+Run the script to print one random headline:
+
+```bash
+python naver_random_title.py
+```
+
+The script downloads the Naver News front page, collects visible article
+links and displays a random title.

--- a/naver_random_title.py
+++ b/naver_random_title.py
@@ -1,0 +1,37 @@
+import random
+from typing import List
+
+import requests
+from bs4 import BeautifulSoup
+
+NAVER_NEWS_URL = "https://news.naver.com"
+
+
+def fetch_article_titles() -> List[str]:
+    """Fetch article titles from Naver News front page."""
+    response = requests.get(NAVER_NEWS_URL)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    titles = []
+    for a in soup.find_all("a"):
+        text = a.get_text(strip=True)
+        if 5 <= len(text) <= 60:  # heuristic to skip navigation labels
+            titles.append(text)
+    return titles
+
+
+def random_title(titles: List[str]) -> str:
+    return random.choice(titles)
+
+
+def main() -> None:
+    titles = fetch_article_titles()
+    if not titles:
+        print("No article titles found.")
+        return
+    print(random_title(titles))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add `naver_random_title.py` that scrapes a random article title from the Naver News home page
- document script usage in README
- declare required libraries in `requirements.txt`

## Testing
- `python naver_random_title.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684046e9ea94832da4a00561eabf5c15